### PR TITLE
Properly set token-based auth in httpie call

### DIFF
--- a/kubectl-http
+++ b/kubectl-http
@@ -11,7 +11,7 @@ fi
 
 # Extract the current context's API server, token, and certificates
 APISERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
-TOKEN=$(kubectl config view --minify -o jsonpath='{.users[0].user.token}')
+TOKEN=$(kubectl config view --minify --raw -o jsonpath='{.users[0].user.token}')
 CA_CERT_DATA=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
 CLIENT_CERT_DATA=$(kubectl config view --minify --raw -o jsonpath='{.users[0].user.client-certificate-data}')
 CLIENT_KEY_DATA=$(kubectl config view --minify --raw -o jsonpath='{.users[0].user.client-key-data}')
@@ -56,9 +56,9 @@ done
 # Determine the authentication method (token or client certificates)
 if [ -n "$TOKEN" ]; then
     # Token-based authentication
-    AUTH_HEADER="Authorization: Bearer $TOKEN"
     http --verify "$CA_CERT" \
-         --default-header "$AUTH_HEADER" \
+         -A bearer \
+         -a "$TOKEN" \
          "${ARGS[@]}"
 elif [ -n "$CLIENT_CERT_DATA" ] && [ -n "$CLIENT_KEY_DATA" ]; then
     # Client certificate-based authentication


### PR DESCRIPTION
Okay, I hope _this_ one is a better PR than #1.

I was trying to use token-based auth, but my `httpie` was complaining about `--default-header` being unknown and when I fixed that, the token was always extracted as REDACTED. The reason for that is that without `--raw`, `kubectl config view --minify -o jsonpath='{.users[0].user.token}'` redacts any secret data like the token. Since the flag is set on all subsequent calls that extract secret data, I think it makes sense to set it here as well.

The flags passed to `httpie` are in accordance with the [httpie auth documentation](https://httpie.io/docs/cli/authentication). Those flags have been around since at least [httpie 3.0.0](https://github.com/httpie/cli/tree/3.0.0/docs#authentication) so they should be save to use, I hope.